### PR TITLE
Change window element lookup to allow for namespaced components

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,12 @@ The `@react_component` directive accepts 3 arguments:
 
   //example
   @react_component('Message', [ 'title' => 'Hello, World' ], [ 'prerender' => true ])
+  
+  // example using namespaced component
+  @react_component('Acme.Message', [ 'title' => 'Hello, World' ], [ 'prerender' => true ])
 ```
 
-* `componentName`: Is the name of the global variable that holds your component.
+* `componentName`: Is the name of the global variable that holds your component.  When using [Namespaced Components](https://facebook.github.io/react/docs/jsx-in-depth.html#namespaced-components) you may use dot-notation for the component name.
 * `props`: Associative of the `props` that'll be passed to your component
 * `options`: Associative array of options that you can pass to the `react-laravel`:
   * `prerender`: Tells react-laravel to render your component server-side, and then just _mount_ it on the client-side. Default to __true__.

--- a/assets/react_ujs.js
+++ b/assets/react_ujs.js
@@ -23,7 +23,7 @@
       var reactClass;
       var props;
 
-      function index(obj, i) {
+      var index = function index(obj, i) {
         return obj[i];
       };
 

--- a/assets/react_ujs.js
+++ b/assets/react_ujs.js
@@ -23,7 +23,9 @@
       var reactClass;
       var props;
 
-      function index(obj,i) {return obj[i]}
+      function index(obj, i) {
+        return obj[i];
+      };
 
       for(var i = 0; i < elements.length; i++) {
         element = elements[i];

--- a/assets/react_ujs.js
+++ b/assets/react_ujs.js
@@ -23,9 +23,11 @@
       var reactClass;
       var props;
 
+      function index(obj,i) {return obj[i]}
+
       for(var i = 0; i < elements.length; i++) {
         element = elements[i];
-        reactClass = window[element.getAttribute(ReactLaravelUJS.CLASS_NAME_ATTR)];
+        reactClass = element.getAttribute(ReactLaravelUJS.CLASS_NAME_ATTR).split('.').reduce(index, window);
         props = JSON.parse(element.getAttribute(ReactLaravelUJS.PROPS_ATTR));
 
         React.render(React.createElement(reactClass, props), element);


### PR DESCRIPTION
I would like the ability to use namespaced react components instead of placing all of my elements in the global namespace.

@react_component('XYZ.Button', $props, ['prerender' => true])

instead of 

@react_component('Button', $props, ['prerender' => true])

This is just splitting the string using dot-notation for the window lookup.
