### PR TITLE
Fixed a race condition where the document loads before the script

### DIFF
--- a/assets/react_ujs.js
+++ b/assets/react_ujs.js
@@ -45,7 +45,12 @@
     },
 
     handleEvents: function handleEvents() {
-      document.addEventListener('DOMContentLoaded', ReactLaravelUJS.mountComponents);
+      if (document.readyState == "complete" || document.readyState == "loaded" || document.readyState == "interactive") {
+        ReactLaravelUJS.mountComponents();
+      }
+      else {
+        document.addEventListener('DOMContentLoaded', ReactLaravelUJS.mountComponents);
+      }
       window.addEventListener('unload', ReactLaravelUJS.unmountComponents);
     }
   };


### PR DESCRIPTION
There was an issue causing react components not to mount when the DOM has loaded before the script has been downloaded and ran. This pull requests checks essentially if the DOMContentLoaded event has fired already and then mounts the components if it has.
