### PR TITLE
Added Regex Modifier (PCRE_DOTALL) to ReactServiceProvider->createMatcher

### DIFF
--- a/lib/ReactServiceProvider.php
+++ b/lib/ReactServiceProvider.php
@@ -64,6 +64,6 @@ class ReactServiceProvider extends ServiceProvider {
   }
 
   protected function createMatcher($function) {
-    return '/(?<!\w)(\s*)@' . $function . '(\s*\(.*\))/';
+    return '/(?<!\w)(\s*)@' . $function . '(\s*\(.*\))/s';
   }
 }


### PR DESCRIPTION
Great project, thanks for sharing it.

I've added the PCRE_DOTALL modifier to the ReactServiceProvider.php createMatcher method to capture new lines (http://php.net/manual/en/reference.pcre.pattern.modifiers.php).

So before, this was failing to be rendered:

``` PHP
    @react_component('Message', [
        'title'=>'My Website Title'
    ])
```

Very small commit, but I ran the unit tests anyway :)
Thanks,

Alex
