### PR TITLE
Changed createMatcher Regex

### DIFF
--- a/lib/ReactServiceProvider.php
+++ b/lib/ReactServiceProvider.php
@@ -64,6 +64,6 @@ class ReactServiceProvider extends ServiceProvider {
   }
 
   protected function createMatcher($function) {
-    return '/(?<!\w)(\s*)@' . $function . '(\s*\(.*\))/s';
+    return '/(?<!\w)(\s*)@' . $function . '(\s*\([\s\S]*?\))/';
   }
 }


### PR DESCRIPTION
Hi,

I've changed the regex on the createMatcher method on the ReactServiceProvider class again.

The match is now non-greedy on the final bracket. If you tried to have two react_components in succession, the regex would parse the first one, but try to match all the way to the end bracket of the second react_component, and it wouldn't get parsed.

I've also changed it to match all whitespace and non-whitespace characters ('\s\S') as it looks a bit cleaner, and means the modifier for new lines can be removed ('s').

I've run the tests and everything passed as well.

Thanks,

Alex
