### PR TITLE
ReactJS Exception Handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "koala-framework/composer-extra-assets": "~1.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0.0@stable"
+    "phpunit/phpunit": "~5.3.0@stable"
   },
   "extra": {
     "require-npm": {

--- a/lib/React.php
+++ b/lib/React.php
@@ -76,4 +76,17 @@
       }
       return $htmlAttributesString;
     }
+
+    /**
+     * Set ReactJS ErrorHandler
+     *
+     * Throws caught V8Js Exception to be caught by default handler (e.g. Whoops)
+     *
+     * @return void;
+     */
+    private function setErrorHandler() {
+      $this->react->setErrorHandler(function(\V8JsException $err) {
+        throw $err;
+      });
+    }
   }

--- a/lib/React.php
+++ b/lib/React.php
@@ -33,6 +33,7 @@
     private function getReact () {
       if ($this->react === null) {
         $this->react = new \ReactJS($this->reactSource, $this->componentsSource);
+        $this->setErrorHandler();
       }
       return $this->react;
     }

--- a/tests/PropagatedExceptionTest.php
+++ b/tests/PropagatedExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use React\React;
+
+class PropagatedExceptionTest extends PHPUnit_Framework_TestCase {
+
+  protected $react;
+
+  public function setUp() {
+    $this->react = new React(
+      $GLOBALS['reactSource'],
+      $GLOBALS['componentsSource']
+    );
+  }
+
+  /**
+   * @expectedException V8JsException
+   */
+  public function testNonExistentComponent() {
+    $randomComponentName = uniqid('react');
+    $elementString = $this->react->render($randomComponentName);
+  }
+
+}

--- a/tests/PropagatedExceptionTest.php
+++ b/tests/PropagatedExceptionTest.php
@@ -13,10 +13,13 @@ class PropagatedExceptionTest extends PHPUnit_Framework_TestCase {
     );
   }
 
-  /**
-   * @expectedException V8JsException
-   */
+  // Clear and close output buffers opened by thrown error
+  public function tearDown() {
+    ob_end_clean();
+  }
+
   public function testNonExistentComponent() {
+    $this->expectException(V8JsException::class);
     $randomComponentName = uniqid('react');
     $elementString = $this->react->render($randomComponentName);
   }


### PR DESCRIPTION
Hi,

At the moment rendering Exceptions are simply dumped to output by ReactJS  #35 .

I've added a very simple handler which simply throws the Exception that's raised so it's caught higher up (Whoops by default). I guess you could do something more clever here and let people pass in their own custom handler for closer control, but it's been ok for now.

![screen shot 2016-04-08 at 20 16 30](https://cloud.githubusercontent.com/assets/12545202/14395298/b522d806-fdc8-11e5-9d81-34f44874a4ff.png)

I've also added a small test to confirm that an exception is raised, for example when it can't find the component to render.

Thanks
