### PR TITLE
Prefer stable version for composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ You just need to add this to your `composer.json`'s `"require"`:
 Also you got to set the `minimum-stability` of your `composer.json` to `dev`, adding this:
 
 ```json
-  "minimum-stability": "dev"
+  "minimum-stability": "dev",
+  "prefer-stable" : true,
 ```
 
 Then run:


### PR DESCRIPTION
If we don't add `"prefer-stable" : true,` then every other dependency upgrades to minimum stability of "dev" and it can break everything. adding this just **allows** composer to use dev dependencies while default behavior keeps normal and stable packages are installed, if available.
